### PR TITLE
Always restart instead of reload rsyslog service

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,6 +2,3 @@
 
 - name: Restart rsyslogd
   service: name=rsyslog state=restarted
-
-- name: Reload rsyslogd
-  service: name=rsyslog state=reloaded

--- a/tasks/pools.yml
+++ b/tasks/pools.yml
@@ -12,7 +12,7 @@
   when: ((item.name is defined and item.name) and
         (item.enabled is defined and item.enabled == True))
   notify:
-    - Reload rsyslogd
+    - Restart rsyslogd
 
 
 - name: Disable rsyslog pools


### PR DESCRIPTION
Fixes the following errors:
* wheezy: 

        msg: Usage: /etc/init.d/rsyslog {start|stop|rotate|restart|force-reload|status}

* jessie/systemd:

         Failed to reload rsyslog.service: Job type reload is not applicable for unit rsyslog.service